### PR TITLE
fix: stabilize mihomo download test across platforms

### DIFF
--- a/libs/mihomo.test.ts
+++ b/libs/mihomo.test.ts
@@ -18,6 +18,8 @@ describe('writeMihomoConfig', () => {
   let tempCwd: string
   let homedirSpy: jest.SpiedFunction<typeof os.homedir>
   let cwdSpy: jest.SpiedFunction<typeof process.cwd>
+  let originalPlatformDescriptor: PropertyDescriptor | undefined
+  let originalArchDescriptor: PropertyDescriptor | undefined
   let originalFetch: typeof global.fetch | undefined
   let originalAppData: string | undefined
 
@@ -26,6 +28,11 @@ describe('writeMihomoConfig', () => {
     tempCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'os-init-mihomo-cwd-'))
     homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(tempHome)
     cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(tempCwd)
+    originalPlatformDescriptor = Object.getOwnPropertyDescriptor(
+      process,
+      'platform'
+    )
+    originalArchDescriptor = Object.getOwnPropertyDescriptor(process, 'arch')
     originalFetch = global.fetch
     originalAppData = process.env.APPDATA
     process.env.APPDATA = path.join(tempHome, 'AppData', 'Roaming')
@@ -38,6 +45,12 @@ describe('writeMihomoConfig', () => {
       delete process.env.APPDATA
     } else {
       process.env.APPDATA = originalAppData
+    }
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, 'platform', originalPlatformDescriptor)
+    }
+    if (originalArchDescriptor) {
+      Object.defineProperty(process, 'arch', originalArchDescriptor)
     }
     if (originalFetch === undefined) {
       global.fetch = undefined as unknown as typeof global.fetch
@@ -90,6 +103,15 @@ describe('writeMihomoConfig', () => {
     const targetDir = path.join(tempCwd, 'mihomo-bin')
     const fetchMock = jest.fn()
     const binaryContent = Buffer.from('#!/bin/sh\necho mihomo\n', 'utf8')
+
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux',
+    })
+    Object.defineProperty(process, 'arch', {
+      configurable: true,
+      value: 'x64',
+    })
 
     fetchMock
       .mockResolvedValueOnce({

--- a/libs/mihomo.test.ts
+++ b/libs/mihomo.test.ts
@@ -11,6 +11,7 @@ jest.mock('@gengjiawen/unzip-url', () => ({
   unzip: jest.fn(),
 }))
 
+import { unzip } from '@gengjiawen/unzip-url'
 import { downloadMihomoBinary, writeMihomoConfig } from './mihomo'
 
 describe('writeMihomoConfig', () => {
@@ -22,6 +23,21 @@ describe('writeMihomoConfig', () => {
   let originalArchDescriptor: PropertyDescriptor | undefined
   let originalFetch: typeof global.fetch | undefined
   let originalAppData: string | undefined
+  const unzipMock = unzip as jest.MockedFunction<typeof unzip>
+
+  function setProcessRuntime(
+    platform: NodeJS.Platform,
+    arch: NodeJS.Architecture
+  ): void {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: platform,
+    })
+    Object.defineProperty(process, 'arch', {
+      configurable: true,
+      value: arch,
+    })
+  }
 
   beforeEach(() => {
     tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'os-init-mihomo-'))
@@ -36,6 +52,7 @@ describe('writeMihomoConfig', () => {
     originalFetch = global.fetch
     originalAppData = process.env.APPDATA
     process.env.APPDATA = path.join(tempHome, 'AppData', 'Roaming')
+    unzipMock.mockReset()
   })
 
   afterEach(() => {
@@ -99,19 +116,12 @@ describe('writeMihomoConfig', () => {
     expect(fs.existsSync(customPath)).toBe(true)
   })
 
-  test('downloads mihomo binary when requested', async () => {
+  test('downloads linux mihomo binary and prefers v3 without go tag', async () => {
     const targetDir = path.join(tempCwd, 'mihomo-bin')
     const fetchMock = jest.fn()
     const binaryContent = Buffer.from('#!/bin/sh\necho mihomo\n', 'utf8')
 
-    Object.defineProperty(process, 'platform', {
-      configurable: true,
-      value: 'linux',
-    })
-    Object.defineProperty(process, 'arch', {
-      configurable: true,
-      value: 'x64',
-    })
+    setProcessRuntime('linux', 'x64')
 
     fetchMock
       .mockResolvedValueOnce({
@@ -169,5 +179,115 @@ describe('writeMihomoConfig', () => {
     expect(fs.existsSync(result.binaryPath)).toBe(true)
     expect(fs.readFileSync(result.binaryPath)).toEqual(binaryContent)
     expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('downloads darwin mihomo binary and selects darwin asset', async () => {
+    const targetDir = path.join(tempCwd, 'mihomo-darwin-bin')
+    const fetchMock = jest.fn()
+    const binaryContent = Buffer.from('#!/bin/sh\necho mihomo-darwin\n', 'utf8')
+
+    setProcessRuntime('darwin', 'x64')
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          tag_name: 'v1.19.13',
+          assets: [
+            {
+              name: 'mihomo-linux-amd64-v3-v1.19.13.gz',
+              browser_download_url:
+                'https://example.com/mihomo-linux-amd64-v3-v1.19.13.gz',
+            },
+            {
+              name: 'mihomo-darwin-amd64-v3-go123-v1.19.13.gz',
+              browser_download_url:
+                'https://example.com/mihomo-darwin-amd64-v3-go123-v1.19.13.gz',
+            },
+            {
+              name: 'mihomo-darwin-amd64-v2-v1.19.13.gz',
+              browser_download_url:
+                'https://example.com/mihomo-darwin-amd64-v2-v1.19.13.gz',
+            },
+            {
+              name: 'mihomo-darwin-amd64-v3-v1.19.13.gz',
+              browser_download_url:
+                'https://example.com/mihomo-darwin-amd64-v3-v1.19.13.gz',
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        arrayBuffer: async () => gzipSync(binaryContent),
+      })
+
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const result = await downloadMihomoBinary(targetDir)
+
+    expect(result.version).toBe('v1.19.13')
+    expect(result.binaryPath).toBe(path.join(targetDir, 'mihomo'))
+    expect(result.downloadUrl).toBe(
+      'https://example.com/mihomo-darwin-amd64-v3-v1.19.13.gz'
+    )
+    expect(fs.existsSync(result.binaryPath)).toBe(true)
+    expect(fs.readFileSync(result.binaryPath)).toEqual(binaryContent)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  test('downloads windows mihomo binary and extracts zip asset', async () => {
+    const targetDir = path.join(tempCwd, 'mihomo-windows-bin')
+    const fetchMock = jest.fn()
+    const binaryContent = Buffer.from('windows-mihomo', 'utf8')
+
+    setProcessRuntime('win32', 'x64')
+
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        tag_name: 'v1.19.13',
+        assets: [
+          {
+            name: 'mihomo-linux-amd64-v3-v1.19.13.gz',
+            browser_download_url:
+              'https://example.com/mihomo-linux-amd64-v3-v1.19.13.gz',
+          },
+          {
+            name: 'mihomo-windows-amd64-go123-v1.19.13.zip',
+            browser_download_url:
+              'https://example.com/mihomo-windows-amd64-go123-v1.19.13.zip',
+          },
+          {
+            name: 'mihomo-windows-amd64-v1.19.13.zip',
+            browser_download_url:
+              'https://example.com/mihomo-windows-amd64-v1.19.13.zip',
+          },
+        ],
+      }),
+    })
+
+    unzipMock.mockImplementation(async (_url, destination) => {
+      const nestedDir = path.join(destination, 'nested')
+      fs.mkdirSync(nestedDir, { recursive: true })
+      fs.writeFileSync(path.join(nestedDir, 'mihomo.exe'), binaryContent)
+    })
+
+    global.fetch = fetchMock as unknown as typeof global.fetch
+
+    const result = await downloadMihomoBinary(targetDir)
+
+    expect(result.version).toBe('v1.19.13')
+    expect(result.binaryPath).toBe(path.join(targetDir, 'mihomo.exe'))
+    expect(result.downloadUrl).toBe(
+      'https://example.com/mihomo-windows-amd64-v1.19.13.zip'
+    )
+    expect(fs.existsSync(result.binaryPath)).toBe(true)
+    expect(fs.readFileSync(result.binaryPath)).toEqual(binaryContent)
+    expect(unzipMock).toHaveBeenCalledWith(
+      'https://example.com/mihomo-windows-amd64-v1.19.13.zip',
+      expect.any(String)
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Summary
- fix the mihomo downloader test so it no longer depends on the runner platform
- pin the download test to linux/x64 because the mocked release assets are linux artifacts
- unblock the macOS GitHub Actions matrix job that was failing in pnpm test

## Validation
- pnpm test
- pnpm build
- pnpm format:check

## Context
The failing Actions run was https://github.com/gengjiawen/os-init/actions/runs/23040669653/job/66918071273 .
The macOS runner executed the test with process.platform=darwin, but the mocked release assets only contained mihomo-linux-* artifacts, so asset selection failed before the mocked download could proceed.
