### PR TITLE
fix(codex): Windows TOML parse failure in model_catalog_json merge

### DIFF
--- a/libs/codex.ts
+++ b/libs/codex.ts
@@ -57,8 +57,17 @@ function mergeTomlTables(
   return mergedConfig
 }
 
+/** Strip model_catalog_json before parse; Windows paths break TOML string escapes. */
+function stripModelCatalogJsonFromToml(content: string): string {
+  return content
+    .split('\n')
+    .filter((line) => !/^\s*model_catalog_json\s*=/.test(line))
+    .join('\n')
+}
+
 function getMergedCodexConfig(existingContent: string): string {
-  const existingConfig = TOML.parse(existingContent) as TomlTable
+  const sanitizedContent = stripModelCatalogJsonFromToml(existingContent)
+  const existingConfig = TOML.parse(sanitizedContent) as TomlTable
   const templateConfig = TOML.parse(getCodexConfigTomlTemplate()) as TomlTable
   delete existingConfig.service_tier
   delete existingConfig.model_catalog_json


### PR DESCRIPTION
## Summary

- Fixes Windows CI failure in `libs/codex.test.ts` (`drops model_catalog_json when merging existing codex config`).
- `model_catalog_json` values with Windows paths (e.g. `C:\Users\...`) contain backslashes that TOML treats as escape sequences, causing `TOML.parse` to throw before merge can drop the key.
- Strip `model_catalog_json` lines from raw config before parsing, since merge always removes that key anyway.

## Test plan

- [x] `npx jest libs/codex.test.ts` passes locally
- [ ] GitHub Actions `Node CI` passes on `windows-latest` (the previously failing matrix job)

Fixes https://github.com/gengjiawen/os-init/actions/runs/26083378735/job/76690282624

Assisted-by: Composer

Made with [Cursor](https://cursor.com)